### PR TITLE
Add Sheik at Kakariko always hint

### DIFF
--- a/assets/config.json
+++ b/assets/config.json
@@ -120,6 +120,7 @@
         "Skull Mask":          { "X": 105, "Y": 350 },
         "Biggoron Sword":      { "X": 140, "Y": 350 },
         "Ocarina of Time":     { "X": 175, "Y": 350 },
+        "Sheik at Kakariko":   { "X": 395, "Y": 285 },
         "Frogs 2":             { "X": 210, "Y": 350 },
         "30 Gold Skullutulas": { "X": 0,   "Y": 350 },
         "40 Gold Skullutulas": { "X": 35,  "Y": 350 },

--- a/tracker/draw.go
+++ b/tracker/draw.go
@@ -203,6 +203,11 @@ func (tracker *Tracker) drawHints(screen *ebiten.Image) {
 
 		if v.gfx != nil {
 			op.GeoM.Reset()
+
+			if v.scale != 0 {
+				op.GeoM.Scale(v.scale, v.scale)
+			}
+
 			op.GeoM.Translate(
 				float64(pos.X),
 				float64(pos.Y-margins.Y),
@@ -222,6 +227,7 @@ type drawableHintEntry struct {
 	text    string
 	gfx     *image.Rectangle
 	bgColor color.RGBA
+	scale   float64
 }
 
 var margins = image.Point{3, 15}
@@ -255,7 +261,7 @@ func (tracker *Tracker) getDrawableHintList() []drawableHintEntry {
 			continue
 		}
 
-		entries = append(entries, drawableHintEntry{
+		entry := drawableHintEntry{
 			text:    v,
 			bgColor: color.RGBA{255, 230, 153, 0xFF},
 			gfx: &image.Rectangle{
@@ -265,7 +271,13 @@ func (tracker *Tracker) getDrawableHintList() []drawableHintEntry {
 					tracker.alwaysHints[name].Y + itemSpriteHeight,
 				},
 			},
-		})
+		}
+
+		if name == "Sheik at Kakariko" {
+			entry.scale = 0.7
+		}
+
+		entries = append(entries, entry)
 	}
 
 	return entries

--- a/tracker/hints.go
+++ b/tracker/hints.go
@@ -41,6 +41,7 @@ func (tracker *Tracker) getAlwaysLocations() []string {
 		"Skull Mask",
 		"Biggoron Sword",
 		"Ocarina of Time",
+		"Sheik at Kakariko",
 		"Frogs 2",
 		"30 Gold Skullutulas",
 		"40 Gold Skullutulas",
@@ -70,14 +71,16 @@ func (tracker *Tracker) parseAlways(str string) (int, string) {
 		return 1, parts[1]
 	case "Ocarina of Time":
 		return 2, parts[1]
-	case "Frogs 2":
+	case "Sheik at Kakariko":
 		return 3, parts[1]
-	case "30 Gold Skullutulas":
+	case "Frogs 2":
 		return 4, parts[1]
-	case "40 Gold Skullutulas":
+	case "30 Gold Skullutulas":
 		return 5, parts[1]
-	case "50 Gold Skullutulas":
+	case "40 Gold Skullutulas":
 		return 6, parts[1]
+	case "50 Gold Skullutulas":
+		return 7, parts[1]
 	}
 
 	return -1, ""

--- a/tracker/tracker.go
+++ b/tracker/tracker.go
@@ -31,7 +31,7 @@ type Tracker struct {
 	alwaysHints map[string]image.Point // name => sheet pos
 
 	woths, barrens, sometimes []string
-	always                    [7]string // in order: skull, bigg, 30, 40, 50, OOT, frogs 2
+	always                    [8]string // in order: skull, bigg, OOT, sheik at kak, frogs 2, 30, 40, 50
 
 	dungeonInputMedallionOrder, dungeonInputDungeonKP []string
 
@@ -244,7 +244,7 @@ func (tracker *Tracker) Reset(items []Item, zoneItemMap ZoneItemMap) {
 	tracker.woths = tracker.woths[:0]
 	tracker.barrens = tracker.barrens[:0]
 	tracker.sometimes = tracker.sometimes[:0]
-	tracker.always = [7]string{}
+	tracker.always = [8]string{}
 	tracker.setInitialItems()
 
 	if err := tracker.Save(); err != nil {
@@ -286,7 +286,7 @@ func (tracker Tracker) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Items                     []Item
 		WotHs, Barrens, Sometimes []string
-		Always                    [7]string
+		Always                    [8]string
 		UndoStack, RedoStack      []undoStackEntry
 	}{
 		tracker.items,
@@ -303,7 +303,7 @@ func (tracker *Tracker) loadJSON(r io.Reader) error {
 	var tmp struct {
 		Items                     []Item
 		WotHs, Barrens, Sometimes []string
-		Always                    [7]string
+		Always                    [8]string
 		UndoStack, RedoStack      []undoStackEntry
 	}
 


### PR DESCRIPTION
I've been using your tracker and love it, I'm hoping it's ok to contribute with some changes :) 

Adding the Sheik at Kakariko always hint which is currently a pretty common one. I set the Nocturne of Shadows icon for it, and had to add some logic to resize it as the hint icons are smaller.

There are a couple of other always hints (namely [poes](https://github.com/OoTRandomizer/OoT-Randomizer/blob/Dev/HintList.py#L209) and [link's house cow](https://github.com/OoTRandomizer/OoT-Randomizer/blob/Dev/HintList.py#L461)), not currently used in main rando settings but happy to contribute if welcome as well.